### PR TITLE
removed throws in the async libs, replaced with error handling hooks

### DIFF
--- a/lib/weedfs.js
+++ b/lib/weedfs.js
@@ -26,14 +26,20 @@ WeedFSClient.prototype = {
 	_assign: function(opts, cb) {
 		var ins = this;
 		this.http(this.baseURL + "dir/assign?"+qs.stringify(opts), function(err, resp, body) {
+
 			if (!err) {
+
 				var parsedBody = JSON.parse(body);
 				if (ins.usePublicURLs == true) {
 					parsedBody.url = parsedBody.publicUrl;
 				}
+
 				cb(parsedBody);
+
 			} else {
-				throw err;
+
+				cb({error: err});
+
 			}
 		});
 	},
@@ -62,7 +68,8 @@ WeedFSClient.prototype = {
 
 		this._assign(opts, function(finfo) {
 			if (finfo.error) {
-				throw new Error(finfo.error);
+				// throw new Error(finfo.error);
+				cb(finfo.error, null)
 			}
 
 			if (opts.count) {

--- a/test/tests/find.js
+++ b/test/tests/find.js
@@ -6,6 +6,7 @@ var config = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
 var client = new weedfs(config);
 
 client.write("./tests/test.jpg", function(err, fileInfo) {
+
 	client.find(fileInfo.fid, function(pub, pri) {
 		assert.ok(typeof pub, "array");
 		assert.ok(typeof pri, "array");

--- a/test/tests/multiwrite.js
+++ b/test/tests/multiwrite.js
@@ -7,6 +7,7 @@ var client = new weedfs(config);
 var files  = ["./tests/test.jpg", "./tests/test1.jpg"];
 
 client.write(files, function(err, fileInfo) {
+
 	assert.ok(fileInfo, !null);
 
 	client.remove(fileInfo.fid, function(err, resp, body) {

--- a/test/tests/write.js
+++ b/test/tests/write.js
@@ -6,6 +6,8 @@ var config = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
 var client = new weedfs(config);
 
 client.write("./tests/test.jpg", function(err, fileInfo) {
+
+	assert.ifError(err)
 	assert.ok(fileInfo, !null);
 
 	client.remove(fileInfo.fid, function(err, resp, body) {


### PR DESCRIPTION
It was crashing if the hostname was wrong.  It couldn't be trapped.  I put in some error handling and removed the throws.  It now runs the callbacks with an error indication. 