### PR TITLE
Write calls callback multiple times

### DIFF
--- a/lib/weedfs.js
+++ b/lib/weedfs.js
@@ -70,7 +70,8 @@ WeedFSClient.prototype = {
 		this._assign(opts, function(finfo) {
 			if (finfo.error) {
 				// throw new Error(finfo.error);
-				cb(finfo.error, null)
+				cb(finfo.error, null);
+				return;
 			}
 
             var replies = 0;

--- a/lib/weedfs.js
+++ b/lib/weedfs.js
@@ -26,7 +26,9 @@ WeedFSClient.prototype = {
 	_assign: function(opts, cb) {
 		var ins = this;
 		this.http(this.baseURL + "dir/assign?"+qs.stringify(opts), function(err, resp, body) {
-
+			if (!err && !body) {
+				err = 'Did not receive a valid response.';
+			}
 			if (!err) {
 
 				var parsedBody = JSON.parse(body);


### PR DESCRIPTION
Currently when something goes wrong in write (like if it could not connect to the server) it calls the callback function multiple times. First correctly with the error but because it does not "return" afterwards the code simply keeps on running and then calls it a second time.